### PR TITLE
feature(connector_sdk): minor fix for codex install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,12 @@ See [`claude-code/README.md`](claude-code/README.md) for the full tutorial.
 
 ```bash
 codex plugin marketplace add fivetran/fivetran_csdk_tools
-codex plugin install fivetran-connector-sdk@fivetran-connector-sdk-ai
+codex plugin add fivetran-connector-sdk@fivetran-connector-sdk-ai
 ```
 
 Plugins must also be enabled in `~/.codex/config.toml`. See [`codex/README.md`](codex/README.md) for the full setup.
+
+Note: If your current version of Codex CLI does not support the `add` command, please upgrade to the latest version of Codex CLI.
 
 ### Gemini CLI
 

--- a/codex/README.md
+++ b/codex/README.md
@@ -22,7 +22,7 @@ See the [top-level README](../README.md#install) for the full install matrix. Qu
 2. Add the marketplace and install:
    ```bash
    codex plugin marketplace add fivetran/fivetran_csdk_tools
-   codex plugin install fivetran-connector-sdk@fivetran-connector-sdk-ai
+   codex plugin add fivetran-connector-sdk@fivetran-connector-sdk-ai
    ```
 
 3. Enable the plugin in `~/.codex/config.toml`:


### PR DESCRIPTION
### Changes

The codex install command for the plugin fails with the following :

<img width="1964" height="366" alt="image" src="https://github.com/user-attachments/assets/c0b615f3-371b-4e1a-a147-a3f44de9f40a" />

Updated the command to use `add` command for installing plugins
Also, added a note for upgrading the Codex to the latest version as support for `add` command was added post version 0.132