### PR TITLE
feature(connector_sdk): Rename repo to connector_sdk_tools

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "description": "Build, test, and deploy Fivetran connectors with AI assistance",
       "category": "development",
       "source": "./claude-code",
-      "homepage": "https://github.com/fivetran/fivetran_csdk_tools"
+      "homepage": "https://github.com/fivetran/connector_sdk_tools"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -24,14 +24,14 @@ If you skipped agent setup in `fivetran init`, or want to install the plugin int
 ### Claude Code
 
 ```bash
-claude plugin marketplace add fivetran/fivetran_csdk_tools
+claude plugin marketplace add fivetran/connector_sdk_tools
 claude plugin install fivetran-connector-sdk@fivetran-connector-sdk-ai
 ```
 
 Or from inside a Claude Code session:
 
 ```
-/plugin marketplace add fivetran/fivetran_csdk_tools
+/plugin marketplace add fivetran/connector_sdk_tools
 /plugin install fivetran-connector-sdk@fivetran-connector-sdk-ai
 ```
 
@@ -40,7 +40,7 @@ See [`claude-code/README.md`](claude-code/README.md) for the full tutorial.
 ### Codex CLI
 
 ```bash
-codex plugin marketplace add fivetran/fivetran_csdk_tools
+codex plugin marketplace add fivetran/connector_sdk_tools
 codex plugin add fivetran-connector-sdk@fivetran-connector-sdk-ai
 ```
 
@@ -51,19 +51,19 @@ Note: If your current version of Codex CLI does not support the `add` command, p
 ### Gemini CLI
 
 ```bash
-gemini extensions install https://github.com/fivetran/fivetran_csdk_tools
+gemini extensions install https://github.com/fivetran/connector_sdk_tools
 ```
 
 For non-interactive use (e.g., scripts):
 
 ```bash
-gemini extensions install https://github.com/fivetran/fivetran_csdk_tools --consent --skip-settings
+gemini extensions install https://github.com/fivetran/connector_sdk_tools --consent --skip-settings
 ```
 
 ### GitHub Copilot CLI
 
 ```bash
-copilot plugin marketplace add fivetran/fivetran_csdk_tools
+copilot plugin marketplace add fivetran/connector_sdk_tools
 copilot plugin install fivetran-connector-sdk@fivetran-connector-sdk-ai
 ```
 

--- a/claude-code/README.md
+++ b/claude-code/README.md
@@ -13,14 +13,14 @@ Build, test, fix, and deploy Fivetran connectors with AI assistance, directly in
 See the [top-level README](../README.md#install) for the full install matrix. Quick path:
 
 ```bash
-claude plugin marketplace add fivetran/fivetran_csdk_tools
+claude plugin marketplace add fivetran/connector_sdk_tools
 claude plugin install fivetran-connector-sdk@fivetran-connector-sdk-ai
 ```
 
 Or from inside a Claude Code session:
 
 ```
-/plugin marketplace add fivetran/fivetran_csdk_tools
+/plugin marketplace add fivetran/connector_sdk_tools
 /plugin install fivetran-connector-sdk@fivetran-connector-sdk-ai
 ```
 

--- a/codex/README.md
+++ b/codex/README.md
@@ -21,7 +21,7 @@ See the [top-level README](../README.md#install) for the full install matrix. Qu
 
 2. Add the marketplace and install:
    ```bash
-   codex plugin marketplace add fivetran/fivetran_csdk_tools
+   codex plugin marketplace add fivetran/connector_sdk_tools
    codex plugin add fivetran-connector-sdk@fivetran-connector-sdk-ai
    ```
 

--- a/copilot/README.md
+++ b/copilot/README.md
@@ -14,7 +14,7 @@ Build, test, fix, and deploy Fivetran connectors with AI assistance, directly in
 See the [top-level README](../README.md#install) for the full install matrix. Quick path:
 
 ```bash
-copilot plugin marketplace add fivetran/fivetran_csdk_tools
+copilot plugin marketplace add fivetran/connector_sdk_tools
 copilot plugin install fivetran-connector-sdk@fivetran-connector-sdk-ai
 ```
 


### PR DESCRIPTION
Links https://fivetran.atlassian.net/browse/RD-1217792

Redirection still works
<img width="1239" height="279" alt="Screenshot 2026-06-04 at 1 16 36 PM" src="https://github.com/user-attachments/assets/f2de3d5d-6911-48a1-bfb8-a827639de825" />
