### PR TITLE
feature(agents): plugin versioning

### DIFF
--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -2,7 +2,7 @@
   "name": "fivetran-connector-sdk-ai",
   "metadata": {
     "description": "AI-powered tools for building, testing, and deploying Fivetran connectors",
-    "version": "1.0.0"
+    "version": "2026.6.25.1"
   },
   "owner": {
     "name": "Fivetran",
@@ -13,7 +13,7 @@
       "name": "fivetran-connector-sdk",
       "source": "./copilot",
       "description": "Build, test, and deploy Fivetran connectors with AI assistance",
-      "version": "1.0.0",
+      "version": "2026.6.25.1",
       "skills": [
         "./skills/build-connector",
         "./skills/test-connector",

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -2,7 +2,7 @@
   "name": "fivetran-connector-sdk-ai",
   "metadata": {
     "description": "AI-powered tools for building, testing, and deploying Fivetran connectors",
-    "version": "2026.6.25.1"
+    "version": "2026.7.8.1"
   },
   "owner": {
     "name": "Fivetran",
@@ -13,7 +13,7 @@
       "name": "fivetran-connector-sdk",
       "source": "./copilot",
       "description": "Build, test, and deploy Fivetran connectors with AI assistance",
-      "version": "2026.6.25.1",
+      "version": "2026.7.8.1",
       "skills": [
         "./skills/build-connector",
         "./skills/test-connector",

--- a/README.md
+++ b/README.md
@@ -267,11 +267,23 @@ git add -A
 git commit
 ```
 
-The sync script fans canonical content out into each per-agent tree, prepending the agent's required frontmatter where applicable (e.g., Claude subagent frontmatter, Gemini agent frontmatter).
+The sync script fans canonical content out into each per-agent tree, prepending the agent's required frontmatter where applicable (e.g., Claude subagent frontmatter, Gemini agent frontmatter). Running it again on an already-synced repo produces no diff — it is safe to re-run.
+
+#### Bumping the plugin version
+
+The version in all plugin manifests follows the format `YYYY.M.D.N` (UTC date, no zero-padding, plus a per-day iteration counter). Version updates are **opt-in**: pass `--bump` when you want to tag a new release:
+
+```bash
+bash scripts/sync-plugins.sh --bump
+git add -A
+git commit
+```
+
+Without `--bump` the manifests are left untouched, which keeps routine syncs and the pre-commit hook idempotent — re-running the script never creates a spurious version diff.
 
 ### Pre-commit hook
 
-A hook in `.githooks/pre-commit` runs `sync-plugins.sh` and fails the commit if any generated file would change — i.e., if you edited a canonical file but forgot to re-sync.
+A hook in `.githooks/pre-commit` runs `sync-plugins.sh` (without `--bump`) and fails the commit if any generated file would change — i.e., if you edited a canonical file but forgot to re-sync.
 
 Install once per clone:
 

--- a/claude-code/.claude-plugin/plugin.json
+++ b/claude-code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "fivetran-connector-sdk",
   "description": "Build, test, and deploy Fivetran connectors with AI assistance",
-  "version": "0.5.17.11",
+  "version": "2026.6.25.1",
   "author": {
     "name": "Fivetran"
   }

--- a/claude-code/.claude-plugin/plugin.json
+++ b/claude-code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "fivetran-connector-sdk",
   "description": "Build, test, and deploy Fivetran connectors with AI assistance",
-  "version": "2026.6.25.1",
+  "version": "2026.7.8.1",
   "author": {
     "name": "Fivetran"
   }

--- a/codex/.codex-plugin/plugin.json
+++ b/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fivetran-connector-sdk",
-  "version": "0.5.17.11",
+  "version": "2026.6.25.1",
   "description": "Build, test, and deploy Fivetran connectors with AI assistance",
   "author": {
     "name": "Fivetran"

--- a/codex/.codex-plugin/plugin.json
+++ b/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fivetran-connector-sdk",
-  "version": "2026.6.25.1",
+  "version": "2026.7.8.1",
   "description": "Build, test, and deploy Fivetran connectors with AI assistance",
   "author": {
     "name": "Fivetran"

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "fivetran-connector-sdk",
-  "version": "0.5.17.11",
+  "version": "2026.6.25.1",
   "description": "Build, test, and deploy Fivetran connectors with AI assistance",
   "contextFileName": "GEMINI.md"
 }

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "fivetran-connector-sdk",
-  "version": "2026.6.25.1",
+  "version": "2026.7.8.1",
   "description": "Build, test, and deploy Fivetran connectors with AI assistance",
   "contextFileName": "GEMINI.md"
 }

--- a/scripts/sync-plugins.sh
+++ b/scripts/sync-plugins.sh
@@ -34,19 +34,34 @@
 
 set -euo pipefail
 
+# --- Argument parsing ---
+# --bump   Increment the plugin version. Omit for routine content syncs (e.g.
+#          the pre-commit hook) so the script stays idempotent: running it on
+#          an already-synced repo produces no diff.
+BUMP_VERSION=false
+for arg in "$@"; do
+  case "$arg" in
+    --bump) BUMP_VERSION=true ;;
+    *) echo "Unknown argument: $arg" >&2; exit 1 ;;
+  esac
+done
+
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$REPO_ROOT"
 
 # --- Version management ---
 # Format: YYYY.M.D.N  (e.g. 2026.6.25.1)
 # N auto-increments when multiple releases happen on the same calendar day.
+# Version is only written when --bump is passed; otherwise manifests are left
+# untouched so the pre-commit hook never creates a spurious diff.
 
 _today_prefix() {
-  # Returns YYYY.M.D with no zero-padding (e.g. 2026.6.25)
+  # Returns YYYY.M.D with no zero-padding (e.g. 2026.6.25). Uses UTC so the
+  # version is identical across timezones.
   local y m d
-  y=$(date "+%Y")
-  m=$(date "+%-m" 2>/dev/null || date "+%m" | sed 's/^0//')
-  d=$(date "+%-d" 2>/dev/null || date "+%d" | sed 's/^0//')
+  y=$(date -u "+%Y")
+  m=$(date -u "+%-m" 2>/dev/null || date -u "+%m" | sed 's/^0//')
+  d=$(date -u "+%-d" 2>/dev/null || date -u "+%d" | sed 's/^0//')
   echo "${y}.${m}.${d}"
 }
 
@@ -71,22 +86,25 @@ compute_version() {
   echo "${prefix}.${iteration}"
 }
 
-NEW_VERSION="$(compute_version)"
-echo "Plugin version: $NEW_VERSION"
-
 update_version_in_file() {
   local file="$1"
+  local version="$2"
   # Replace all "version": "..." occurrences in-place.
-  sed -i.bak "s/\"version\"[[:space:]]*:[[:space:]]*\"[^\"]*\"/\"version\": \"${NEW_VERSION}\"/g" "$file"
+  sed -i.bak "s/\"version\"[[:space:]]*:[[:space:]]*\"[^\"]*\"/\"version\": \"${version}\"/g" "$file"
   rm -f "${file}.bak"
   echo "  updated version in $file"
 }
 
-echo "Updating versions..."
-update_version_in_file "claude-code/.claude-plugin/plugin.json"
-update_version_in_file "codex/.codex-plugin/plugin.json"
-update_version_in_file "gemini-extension.json"
-update_version_in_file ".github/plugin/marketplace.json"
+if [[ "$BUMP_VERSION" == true ]]; then
+  NEW_VERSION="$(compute_version)"
+  echo "Bumping plugin version to $NEW_VERSION..."
+  update_version_in_file "claude-code/.claude-plugin/plugin.json" "$NEW_VERSION"
+  update_version_in_file "codex/.codex-plugin/plugin.json" "$NEW_VERSION"
+  update_version_in_file "gemini-extension.json" "$NEW_VERSION"
+  update_version_in_file ".github/plugin/marketplace.json" "$NEW_VERSION"
+else
+  echo "Skipping version bump (pass --bump to increment the version)."
+fi
 
 CANONICAL="canonical"
 SDK_REF="$CANONICAL/sdk-reference.md"

--- a/scripts/sync-plugins.sh
+++ b/scripts/sync-plugins.sh
@@ -37,6 +37,57 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$REPO_ROOT"
 
+# --- Version management ---
+# Format: YYYY.M.D.N  (e.g. 2026.6.25.1)
+# N auto-increments when multiple releases happen on the same calendar day.
+
+_today_prefix() {
+  # Returns YYYY.M.D with no zero-padding (e.g. 2026.6.25)
+  local y m d
+  y=$(date "+%Y")
+  m=$(date "+%-m" 2>/dev/null || date "+%m" | sed 's/^0//')
+  d=$(date "+%-d" 2>/dev/null || date "+%d" | sed 's/^0//')
+  echo "${y}.${m}.${d}"
+}
+
+compute_version() {
+  local prefix
+  prefix="$(_today_prefix)"
+
+  # Read the current version from the Claude plugin manifest (source of truth).
+  local current_version=""
+  local manifest="claude-code/.claude-plugin/plugin.json"
+  if [[ -f "$manifest" ]]; then
+    current_version=$(grep '"version"' "$manifest" | sed 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/')
+  fi
+
+  local iteration=1
+  # If the current version already has today's date prefix, bump the iteration.
+  if [[ "$current_version" == "$prefix."* ]]; then
+    local current_iteration="${current_version##*.}"
+    iteration=$(( current_iteration + 1 ))
+  fi
+
+  echo "${prefix}.${iteration}"
+}
+
+NEW_VERSION="$(compute_version)"
+echo "Plugin version: $NEW_VERSION"
+
+update_version_in_file() {
+  local file="$1"
+  # Replace all "version": "..." occurrences in-place.
+  sed -i.bak "s/\"version\"[[:space:]]*:[[:space:]]*\"[^\"]*\"/\"version\": \"${NEW_VERSION}\"/g" "$file"
+  rm -f "${file}.bak"
+  echo "  updated version in $file"
+}
+
+echo "Updating versions..."
+update_version_in_file "claude-code/.claude-plugin/plugin.json"
+update_version_in_file "codex/.codex-plugin/plugin.json"
+update_version_in_file "gemini-extension.json"
+update_version_in_file ".github/plugin/marketplace.json"
+
 CANONICAL="canonical"
 SDK_REF="$CANONICAL/sdk-reference.md"
 WORKFLOWS_DIR="$CANONICAL/workflows"


### PR DESCRIPTION
Updated the sync_plugin.sh to update the required version in all the agent plugins.
The format of version is <YYYY>.<MM>.<DD>.<N> where N is the iteration ( starts with 1 )

Every update done using the sync_plugin.sh with --bump bumps the version for the plugins
All the plugins use the same version for maintainability