### PR TITLE
Don't let a Windows job-close failure skip the process-kill fallback

### DIFF
--- a/canonical/tools/run_connector.py
+++ b/canonical/tools/run_connector.py
@@ -472,7 +472,11 @@ def run_debug(cmd, connector_dir, timeout_seconds):
         # descendant, e.g. a tester the SDK spawned) even after the immediate
         # `process` has already exited on its own.
         if job is not None:
-            job.close()
+            try:
+                job.close()
+            except OSError:
+                # Don't let a CloseHandle failure skip the process.kill() fallback below.
+                pass
         if process is not None:
             if os.name == "nt":
                 # Also handles failure to assign the gated launcher to the job.

--- a/claude-code/tools/run_connector.py
+++ b/claude-code/tools/run_connector.py
@@ -472,7 +472,11 @@ def run_debug(cmd, connector_dir, timeout_seconds):
         # descendant, e.g. a tester the SDK spawned) even after the immediate
         # `process` has already exited on its own.
         if job is not None:
-            job.close()
+            try:
+                job.close()
+            except OSError:
+                # Don't let a CloseHandle failure skip the process.kill() fallback below.
+                pass
         if process is not None:
             if os.name == "nt":
                 # Also handles failure to assign the gated launcher to the job.

--- a/codex/tools/run_connector.py
+++ b/codex/tools/run_connector.py
@@ -472,7 +472,11 @@ def run_debug(cmd, connector_dir, timeout_seconds):
         # descendant, e.g. a tester the SDK spawned) even after the immediate
         # `process` has already exited on its own.
         if job is not None:
-            job.close()
+            try:
+                job.close()
+            except OSError:
+                # Don't let a CloseHandle failure skip the process.kill() fallback below.
+                pass
         if process is not None:
             if os.name == "nt":
                 # Also handles failure to assign the gated launcher to the job.

--- a/copilot/tools/run_connector.py
+++ b/copilot/tools/run_connector.py
@@ -472,7 +472,11 @@ def run_debug(cmd, connector_dir, timeout_seconds):
         # descendant, e.g. a tester the SDK spawned) even after the immediate
         # `process` has already exited on its own.
         if job is not None:
-            job.close()
+            try:
+                job.close()
+            except OSError:
+                # Don't let a CloseHandle failure skip the process.kill() fallback below.
+                pass
         if process is not None:
             if os.name == "nt":
                 # Also handles failure to assign the gated launcher to the job.

--- a/tools/run_connector.py
+++ b/tools/run_connector.py
@@ -472,7 +472,11 @@ def run_debug(cmd, connector_dir, timeout_seconds):
         # descendant, e.g. a tester the SDK spawned) even after the immediate
         # `process` has already exited on its own.
         if job is not None:
-            job.close()
+            try:
+                job.close()
+            except OSError:
+                # Don't let a CloseHandle failure skip the process.kill() fallback below.
+                pass
         if process is not None:
             if os.name == "nt":
                 # Also handles failure to assign the gated launcher to the job.


### PR DESCRIPTION
## Summary
- `stop_tree()` in `run_connector.py` called `job.close()` without a try/except; if `CloseHandle` fails on Windows, `WindowsJob.close()` raises past `stop_tree()`, skipping the `process.kill()` fallback below it.
- When this happens on the timeout `Timer` thread, the exception dies silently in that background thread, the child process is never killed, and the main thread stays blocked reading its inherited stdout indefinitely — defeating the timeout entirely.
- This was an [open Copilot review comment on PR #19](https://github.com/fivetran/connector_sdk_tools/pull/19#discussion_r) that was never addressed before that PR was merged.

Fix: wrap `job.close()` in `try/except OSError` so a `CloseHandle` failure no longer blocks the `process.kill()` fallback.

Applied to `canonical/tools/run_connector.py` and synced to all plugin copies (`claude-code/`, `codex/`, `copilot/`, root `tools/`) via `scripts/sync-plugins.sh`.

## Test plan
- [x] `python3 -m pytest tests/` — 28 passed, 1 skipped (Windows-only Job Object test, expected on macOS)
- [ ] Manual verification on Windows that a `CloseHandle` failure still results in the child being killed (not testable on this machine)

🤖 Generated with [Claude Code](https://claude.com/claude-code)